### PR TITLE
Improve Firestore queries for Categories

### DIFF
--- a/LanguageApp/app/screens/CategoriesScreen.js
+++ b/LanguageApp/app/screens/CategoriesScreen.js
@@ -39,7 +39,6 @@ function CategoriesScreen({ route, navigation }) {
         setIsLoading(false);
       })
       .catch((err) => {
-        console.log(err);
         setIsLoading(false);
         setError(err);
       });

--- a/LanguageApp/app/screens/CategoriesScreen.js
+++ b/LanguageApp/app/screens/CategoriesScreen.js
@@ -17,16 +17,28 @@ function CategoriesScreen({ route, navigation }) {
   const getCategories = async () => {
     let categoryArray = [];
 
-    db.collection("Categories")
+    let categoryQuery = db.collection("Categories");
+
+    if (route.params.user_type === "LL") {
+      categoryQuery = categoryQuery.where(
+        "hasContent",
+        "array-contains",
+        route.params.language
+      );
+    }
+
+    categoryQuery
       .get()
       .then((querySnapshot) => {
         querySnapshot.forEach((documentSnapshot) => {
           categoryArray.push(documentSnapshot.data());
         });
+
         setCategories(categoryArray);
         setIsLoading(false);
       })
       .catch((err) => {
+        console.log(err);
         setIsLoading(false);
         setError(err);
       });

--- a/LanguageApp/app/screens/CategoriesScreen.js
+++ b/LanguageApp/app/screens/CategoriesScreen.js
@@ -19,6 +19,7 @@ function CategoriesScreen({ route, navigation }) {
 
     let categoryQuery = db.collection("Categories");
 
+    // Restrict contents of LL screen to categories that have content in the selected language
     if (route.params.user_type === "LL") {
       categoryQuery = categoryQuery.where(
         "hasContent",

--- a/LanguageApp/app/screens/LanguagesScreen.js
+++ b/LanguageApp/app/screens/LanguagesScreen.js
@@ -18,14 +18,15 @@ function LanguagesScreen({ route, navigation }) {
     let languageArray = [];
     let query = db.collection("Languages");
 
-    if (route.params.type === "LL") {
+    if (route.params.user_type === "LL") {
       query = query.where("hasContent", "==", true);
     }
     await query
       .get()
       .then((querySnapshot) => {
         querySnapshot.forEach((documentSnapshot) => {
-          languageArray.push(documentSnapshot.data());
+          const id = documentSnapshot.id;
+          languageArray.push({ id: id, ...documentSnapshot.data() });
         });
       })
       .catch((err) => {
@@ -63,6 +64,7 @@ function LanguagesScreen({ route, navigation }) {
             onPress={() =>
               navigation.navigate(routes.CATEGORIES, {
                 language: item.englishName,
+                language_key: item.id,
                 user_type: route.params.user_type,
               })
             }

--- a/LanguageApp/app/screens/UserTypeScreen.js
+++ b/LanguageApp/app/screens/UserTypeScreen.js
@@ -20,7 +20,9 @@ function UserTypeScreen({ navigation }) {
         />
         <AppButton
           title="Language Learner"
-          onPress={() => navigation.navigate(routes.LANGUAGES, { type: "LL" })}
+          onPress={() =>
+            navigation.navigate(routes.LANGUAGES, { user_type: "LL" })
+          }
         />
       </View>
     </Screen>


### PR DESCRIPTION
This PR accomplishes the following:
- Restricts the categories that appear in the LL categories screen to those that have content in the user's selected language.
- Add 'id' to the Languages array on the languages page.

The reason why the ID has been added is that I thought the `hasContent` attribute in Categories would contain language IDs instead of language names. I'm unsure if the data will ultimately look like that, but I have kept the language ID to make this easy to change.

For the CP, I have decided to display all categories because, if `hasContent` contains the specified language, that does not mean that all scenarios are translated yet.

### References ###
- David's Firebase Interaction Document: [https://docs.google.com/document/d/1lK5oRGKwl_T8Eu0yhTSAyq1PNl1ngU1gB-DzcNCkHW8/edit](https://docs.google.com/document/d/1lK5oRGKwl_T8Eu0yhTSAyq1PNl1ngU1gB-DzcNCkHW8/edit )