### PR TITLE
Speech to text

### DIFF
--- a/LanguageApp/app/components/SoundButton.js
+++ b/LanguageApp/app/components/SoundButton.js
@@ -12,6 +12,7 @@ function AppButtonSecondary({ title, uri, color }) {
     btnTextColor = colors.primary;
   }
 
+  const [error, setError] = useState(null);
   const [cpRecording, setCpRecording] = useState();
   const [sound, setSound] = useState();
 
@@ -40,6 +41,10 @@ function AppButtonSecondary({ title, uri, color }) {
   useEffect(() => {
     getAudioUrl();
   }, []);
+
+  if (error) {
+    return <ErrorMessage message="Error fetching data" />;
+  }
 
   return (
     <TouchableOpacity

--- a/LanguageApp/app/components/SpeechToTextButton.js
+++ b/LanguageApp/app/components/SpeechToTextButton.js
@@ -3,7 +3,7 @@ import { View, StyleSheet, Pressable } from "react-native";
 import { Audio } from "expo-av";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import * as FileSystem from "expo-file-system";
-import { FLASK_BACKEND } from "@env";
+import { DOMAIN } from "@env";
 import LoadingSign from "./LoadingSign";
 
 function SpeechToTextButton({ getTranscription, languageCode }) {
@@ -50,11 +50,9 @@ function SpeechToTextButton({ getTranscription, languageCode }) {
     setIsProcessing(true);
     try {
       getTranscription("Processing...");
-      const api = FLASK_BACKEND + languageCode;
+      const api = `https://${DOMAIN}/audio/` + languageCode;
       const response = await FileSystem.uploadAsync(api, uri);
-      console.log(response);
       const body = JSON.parse(response.body);
-      console.log(body.text);
       getTranscription(body.text);
     } catch (err) {
       console.error("Failed to stop recording", err);

--- a/LanguageApp/app/components/SpeechToTextButton.js
+++ b/LanguageApp/app/components/SpeechToTextButton.js
@@ -49,6 +49,7 @@ function SpeechToTextButton({ getTranscription, languageCode }) {
 
     setIsProcessing(true);
     try {
+      getTranscription("Processing...");
       const api = FLASK_BACKEND + languageCode;
       const response = await FileSystem.uploadAsync(api, uri);
       console.log(response);

--- a/LanguageApp/app/components/SpeechToTextButton.js
+++ b/LanguageApp/app/components/SpeechToTextButton.js
@@ -1,0 +1,108 @@
+import React, { useState } from "react";
+import { View, StyleSheet, Pressable } from "react-native";
+import { Audio } from "expo-av";
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import * as FileSystem from "expo-file-system";
+import { FLASK_BACKEND } from "@env";
+import LoadingSign from "./LoadingSign";
+
+function SpeechToTextButton({ getTranscription, languageCode }) {
+  const [recording, setRecording] = useState();
+  const [isRecording, setIsRecording] = useState(false);
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  async function startRecording() {
+    setIsRecording(true);
+    try {
+      await Audio.requestPermissionsAsync();
+      await Audio.setAudioModeAsync({
+        allowsRecordingIOS: true,
+        playsInSilentModeIOS: true,
+      });
+      const { recording } = await Audio.Recording.createAsync({
+        android: {
+          extension: ".amr",
+          audioEncoder: Audio.RECORDING_OPTION_ANDROID_AUDIO_ENCODER_AMR_WB,
+          outputFormat: Audio.RECORDING_OPTION_ANDROID_OUTPUT_FORMAT_AMR_WB,
+        },
+        ios: {
+          extension: ".amr",
+          sampleRate: 44100,
+          numberOfChannels: 2,
+          bitRate: 128000,
+          audioQuality: Audio.RECORDING_OPTION_IOS_AUDIO_QUALITY_HIGH,
+          outputFormat: Audio.RECORDING_OPTION_IOS_OUTPUT_FORMAT_AMR_WB,
+        },
+      });
+      setRecording(recording);
+    } catch (err) {
+      stopRecording;
+      console.error("Failed to start recording", err);
+    }
+  }
+
+  async function stopRecording() {
+    setIsRecording(false);
+    setRecording(undefined);
+    await recording.stopAndUnloadAsync();
+    const uri = recording.getURI();
+
+    setIsProcessing(true);
+    try {
+      const api = FLASK_BACKEND + languageCode;
+      const response = await FileSystem.uploadAsync(api, uri);
+      console.log(response);
+      const body = JSON.parse(response.body);
+      console.log(body.text);
+      getTranscription(body.text);
+    } catch (err) {
+      console.error("Failed to stop recording", err);
+    }
+    setIsProcessing(false);
+  }
+
+  return (
+    <View style={styles.container}>
+      <Pressable
+        onPressIn={startRecording}
+        onPressOut={stopRecording}
+        style={[styles.button, isRecording && styles.dim]}
+      >
+        <View style={styles.icon}>
+          {isProcessing ? (
+            <LoadingSign />
+          ) : (
+            <MaterialCommunityIcons name="microphone" size={40} />
+          )}
+        </View>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  button: {
+    width: 70,
+    height: 70,
+    backgroundColor: "white",
+    borderRadius: 50,
+    borderColor: "black",
+    borderWidth: 3,
+    marginVertical: 10,
+  },
+  dim: {
+    opacity: 0.2,
+  },
+  icon: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+});
+
+export default SpeechToTextButton;

--- a/LanguageApp/app/screens/CategoriesScreen.js
+++ b/LanguageApp/app/screens/CategoriesScreen.js
@@ -73,10 +73,11 @@ function CategoriesScreen({ route, navigation }) {
             onPress={() =>
               navigation.navigate(routes.SCENARIOS, {
                 language: route.params.language,
+                language_code: route.params.language_code,
                 category: item.name,
                 user_type: route.params.user_type,
                 language_key: route.params.language_key,
-                category_key: item.id
+                category_key: item.id,
               })
             }
           />

--- a/LanguageApp/app/screens/LanguagesScreen.js
+++ b/LanguageApp/app/screens/LanguagesScreen.js
@@ -64,6 +64,7 @@ function LanguagesScreen({ route, navigation }) {
             onPress={() =>
               navigation.navigate(routes.CATEGORIES, {
                 language: item.englishName,
+                language_code: item.code,
                 language_key: item.id,
                 user_type: route.params.user_type,
               })

--- a/LanguageApp/app/screens/LearnerScenarioScreen.js
+++ b/LanguageApp/app/screens/LearnerScenarioScreen.js
@@ -1,9 +1,6 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Alert, StyleSheet, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
-import { Audio } from "expo-av";
-
-import colors from "../config/colors";
 
 import AppButton from "../components/AppButton";
 import AppTextInput from "../components/AppTextInput";
@@ -11,58 +8,21 @@ import AppText from "../components/AppText";
 import ScenarioImage from "../components/ScenarioImage";
 import AppButtonSecondary from "../components/AppButtonSecondary";
 import SoundButton from "../components/SoundButton";
+import SpeechToTextButton from "../components/SpeechToTextButton";
+
+import colors from "../config/colors";
 
 function LearnerScenarioScreen({ route }) {
-  const [scenario, setScenario] = useState(route.params);
-  const [error, setError] = useState(null);
+  const scenario = route.params;
 
-  /* To store Audio recordings */
-  // Stores all of recording object, (sound, uri, duration, etc..), resets to undefined in stopRecording because used in if/else
-  const [recording, setRecording] = useState();
-  //Stores just the recording URI
-  const [llanswerAudio, setllAnswerAudio] = useState();
-  //Stores LL answer text
   const [llAnswer, setllAnswer] = useState("");
 
-  /* TO DO: Add functionality to compare LL and CP answers, convert speech-to-text as necessary */
+  /* TO DO: Add functionality to compare LL and CP answers */
   const gradeTranslation = async () => {
-    // If audio -> speech-to-text, update text state with setllAnswer
     // determine distancde-wise match
     // send alert about correct/try again
     console.log("grading the answer");
   };
-
-  /* For recording audio using expo-av */
-  async function startRecording() {
-    try {
-      console.log("Requesting permissions..");
-      await Audio.requestPermissionsAsync();
-      await Audio.setAudioModeAsync({
-        allowsRecordingIOS: true,
-        playsInSilentModeIOS: true,
-      });
-      console.log("Starting recording..");
-      const { recording } = await Audio.Recording.createAsync(
-        Audio.RECORDING_OPTIONS_PRESET_HIGH_QUALITY
-      );
-      setRecording(recording);
-      console.log("Recording started");
-    } catch (err) {
-      console.error("Failed to start recording", err);
-    }
-  }
-
-  async function stopRecording() {
-    console.log("Stopping recording..");
-    setRecording(undefined);
-    await recording.stopAndUnloadAsync();
-    setllAnswerAudio(recording.getURI());
-    console.log("Recording stopped and stored at", recording.getURI());
-  }
-
-  if (error) {
-    return <ErrorMessage message="Error fetching data" />;
-  }
 
   return (
     <View>
@@ -79,15 +39,13 @@ function LearnerScenarioScreen({ route }) {
             {scenario.promptTranslation[scenario.language]}
           </AppText>
 
-          <View style={styles.spacer}></View>
-
-          <AppButtonSecondary
-            title={recording ? "Stop Recording" : "Record Answer"}
-            onPress={recording ? stopRecording : startRecording}
-            color={colors.lightBlue}
+          <SpeechToTextButton
+            getTranscription={(transcription) => setllAnswer(transcription)}
+            languageCode={scenario.language_code}
           />
+
           <AppTextInput
-            // style={styles.input}
+            value={llAnswer}
             placeholder="Type Answer Translation"
             onChangeText={(value) => setllAnswer(value)}
           />
@@ -132,13 +90,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     padding: 20,
-  },
-  input: {
-    height: 40,
-    margin: 12,
-    borderWidth: 1,
-    width: "100%",
-    padding: 10,
   },
   spacer: {
     margin: 20,

--- a/LanguageApp/app/screens/ScenariosScreen.js
+++ b/LanguageApp/app/screens/ScenariosScreen.js
@@ -119,6 +119,7 @@ function ScenariosScreen({ route, navigation }) {
               } else {
                 navigation.navigate(routes.LEARNER_SCENARIO, {
                   language: route.params.language,
+                  language_code: route.params.language_code,
                   ...item,
                 });
               }

--- a/LanguageApp/package-lock.json
+++ b/LanguageApp/package-lock.json
@@ -12,6 +12,7 @@
         "@react-navigation/stack": "^6.1.1",
         "expo": "~44.0.0",
         "expo-av": "^10.2.0",
+        "expo-file-system": "~13.1.4",
         "expo-status-bar": "~1.2.0",
         "firebase": "^9.6.6",
         "react": "17.0.1",
@@ -5272,9 +5273,9 @@
       }
     },
     "node_modules/expo-file-system": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-13.1.2.tgz",
-      "integrity": "sha512-TA0LZTi8ZlnmyB2q6rEuTEo7b63e2luBzNhR5h/ow2J55xxRTXQLeaoK9m69XgazLVq6Ys7wiJma/q+Hg38hrQ==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-13.1.4.tgz",
+      "integrity": "sha512-/C2FKCzrdWuEt4m8Pzl9J4MhKgfU0denVLbqoKjidv8DnsLQrscFNlLhXuiooqWwsxB2OWAtGEVnPGJBWVuNEQ==",
       "dependencies": {
         "@expo/config-plugins": "^4.0.2",
         "uuid": "^3.4.0"
@@ -14621,9 +14622,9 @@
       "requires": {}
     },
     "expo-file-system": {
-      "version": "13.1.2",
-      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-13.1.2.tgz",
-      "integrity": "sha512-TA0LZTi8ZlnmyB2q6rEuTEo7b63e2luBzNhR5h/ow2J55xxRTXQLeaoK9m69XgazLVq6Ys7wiJma/q+Hg38hrQ==",
+      "version": "13.1.4",
+      "resolved": "https://registry.npmjs.org/expo-file-system/-/expo-file-system-13.1.4.tgz",
+      "integrity": "sha512-/C2FKCzrdWuEt4m8Pzl9J4MhKgfU0denVLbqoKjidv8DnsLQrscFNlLhXuiooqWwsxB2OWAtGEVnPGJBWVuNEQ==",
       "requires": {
         "@expo/config-plugins": "^4.0.2",
         "uuid": "^3.4.0"

--- a/LanguageApp/package.json
+++ b/LanguageApp/package.json
@@ -24,7 +24,8 @@
     "react-native-keyboard-aware-scroll-view": "^0.9.5",
     "react-native-safe-area-context": "3.3.2",
     "react-native-screens": "~3.10.1",
-    "react-native-web": "0.17.1"
+    "react-native-web": "0.17.1",
+    "expo-file-system": "~13.1.4"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
-Added Speech To Text Feature to the LearnerScenarioScreen. 
-Created a separate SpeechToTextButton component to keep all recording associated functions outside the learner scenario screen. Made it so it simulates the classic speech to text feature, where recording stops after the release of the button. 
-If no recording was captured or the API was not able to transcribe it, the error message currently appears in the input box, but will move it next to the button in the future.
-In terms of the audio configuration for transcription, it works well with Android. I have not tested with iOs.
-Added the language code field to Languages in Firestore. The code will be passed down through the screens so the speech to text API can use it to determine the language to transcribe. 
-The Speech to text API created is hosted on google Cloud. The URL will be provided. Please save the domain of the url in a variable in the .env file:  DOMAIN="[domain of url]" 