### PR TITLE
Language id update

### DIFF
--- a/LanguageApp/app/components/RecordButton.js
+++ b/LanguageApp/app/components/RecordButton.js
@@ -34,7 +34,6 @@ function RecordButton({ type, getReference, scenarioID, language }) {
     setRecording(undefined);
     await recording.stopAndUnloadAsync();
     const uri = recording.getURI();
-    console.log(uri);
     await updateStorage(uri);
   }
 
@@ -66,7 +65,7 @@ function RecordButton({ type, getReference, scenarioID, language }) {
         const uriParts = uri.split(".");
         const fileType = uriParts[uriParts.length - 1];
         const fileName = scenarioID + language + type + "." + fileType;
-        const filePath = `/cp-audio/${fileName}`
+        const filePath = `/cp-audio/${fileName}`;
         storage
           .ref()
           .child(`${filePath}`)

--- a/LanguageApp/app/components/SoundButton.js
+++ b/LanguageApp/app/components/SoundButton.js
@@ -30,7 +30,6 @@ function AppButtonSecondary({ title, uri, color }) {
   };
   /* Playing audio function based upon documentation: https://docs.expo.dev/versions/latest/sdk/audio/ */
   async function playSound() {
-    console.log("cpRecording: ", cpRecording);
     const { sound } = await Audio.Sound.createAsync({
       uri: cpRecording,
     });

--- a/LanguageApp/app/screens/CategoriesScreen.js
+++ b/LanguageApp/app/screens/CategoriesScreen.js
@@ -76,7 +76,7 @@ function CategoriesScreen({ route, navigation }) {
                 language_code: route.params.language_code,
                 category: item.name,
                 user_type: route.params.user_type,
-                language_key: route.params.language_key,
+
                 category_key: item.id,
                 languageHasContent: route.params.languageHasContent,
                 categoryHasContent: item.hasContent,

--- a/LanguageApp/app/screens/LanguagesScreen.js
+++ b/LanguageApp/app/screens/LanguagesScreen.js
@@ -56,7 +56,7 @@ function LanguagesScreen({ route, navigation }) {
       <ListItemSeparator />
       <FlatList
         data={languages}
-        keyExtractor={(language) => language.englishName}
+        keyExtractor={(language) => language.id}
         renderItem={({ item }) => (
           <ListItem
             title={item.id}

--- a/LanguageApp/app/screens/LanguagesScreen.js
+++ b/LanguageApp/app/screens/LanguagesScreen.js
@@ -22,7 +22,6 @@ function LanguagesScreen({ route, navigation }) {
       query = query.where("hasContent", "==", true);
     }
     await query
-      .orderBy("englishName")
       .get()
       .then((querySnapshot) => {
         querySnapshot.forEach((documentSnapshot) => {
@@ -60,13 +59,12 @@ function LanguagesScreen({ route, navigation }) {
         keyExtractor={(language) => language.englishName}
         renderItem={({ item }) => (
           <ListItem
-            title={item.englishName}
+            title={item.id}
             imageLink={item.flag}
             onPress={() => {
               navigation.navigate(routes.CATEGORIES, {
-                language: item.englishName,
+                language: item.id,
                 language_code: item.code,
-                language_key: item.id,
                 user_type: route.params.user_type,
                 languageHasContent: item.hasContent,
               });

--- a/LanguageApp/app/screens/ProviderScenarioScreen.js
+++ b/LanguageApp/app/screens/ProviderScenarioScreen.js
@@ -88,7 +88,7 @@ function ProviderScenarioScreen({ route, navigation }) {
     let updateError = false;
     await db
       .collection("Languages")
-      .doc(scenario.language_key)
+      .doc(scenario.language)
       .update({
         hasContent: true,
       })
@@ -157,7 +157,7 @@ function ProviderScenarioScreen({ route, navigation }) {
   const resetLanguage = async () => {
     await db
       .collection("Languages")
-      .doc(scenario.language_key)
+      .doc(scenario.language)
       .update({
         hasContent: false,
       })
@@ -206,7 +206,6 @@ function ProviderScenarioScreen({ route, navigation }) {
       language_code: scenario.language_code,
       category: scenario.category,
       user_type: "CP",
-      language_key: scenario.language_key,
       category_key: scenario.category_key,
       languageHasContent: languageHasContent,
       categoryHasContent: categoryHasContent,

--- a/LanguageApp/app/screens/ScenariosScreen.js
+++ b/LanguageApp/app/screens/ScenariosScreen.js
@@ -116,7 +116,6 @@ function ScenariosScreen({ route, navigation }) {
               if (route.params.user_type === "CP") {
                 navigation.navigate(routes.PROVIDER_SCENARIO, {
                   language: route.params.language,
-                  language_key: route.params.language_key,
                   category_key: route.params.category_key,
                   languageHasContent: route.params.languageHasContent,
                   categoryHasContent: route.params.categoryHasContent,


### PR DESCRIPTION
Updated all references to the Firestore language document field englishName and the route parameter language_key to reflect updates in Firestore. 

To follow Firestore best practices the document id for language documents is the English name. The field englishName is removed from all language documents. 

In this PR, all references to englishName now reference id. Removed the route parameter language_key since it is now redundant with the route parameter language. Updated references to language_key accordingly. 

Removed some console.log() statements as they are unnecessary. 